### PR TITLE
Treat STM32F411 like STM32F401 for clock setup - #1

### DIFF
--- a/src/stm32/stm32f4.c
+++ b/src/stm32/stm32f4.c
@@ -18,7 +18,7 @@
  * Clock setup
  ****************************************************************/
 
-#define FREQ_PERIPH_DIV (CONFIG_MACH_STM32F401 ? 2 : 4)
+#define FREQ_PERIPH_DIV ((CONFIG_MACH_STM32F401 || CONFIG_MACH_STM32F411) ? 2 : 4)
 #define FREQ_PERIPH (CONFIG_CLOCK_FREQ / FREQ_PERIPH_DIV)
 #define FREQ_USB 48000000
 
@@ -87,9 +87,9 @@ enable_clock_stm32f20x(void)
 static void
 enable_clock_stm32f40x(void)
 {
-#if CONFIG_MACH_STM32F401 || CONFIG_MACH_STM32F4x5
+#if CONFIG_MACH_STM32F401 || CONFIG_MACH_STM32F411 || CONFIG_MACH_STM32F4x5
     uint32_t pll_base = (CONFIG_STM32_CLOCK_REF_25M) ? 1000000 : 2000000;
-    uint32_t pllp = (CONFIG_MACH_STM32F401) ? 4 : 2;
+    uint32_t pllp = (CONFIG_MACH_STM32F401 || CONFIG_MACH_STM32F411) ? 4 : 2;
     uint32_t pll_freq = CONFIG_CLOCK_FREQ * pllp, pllcfgr;
     if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
         // Configure 168Mhz PLL from external crystal (HSE)
@@ -172,7 +172,7 @@ clock_setup(void)
     // Configure and enable PLL
     if (CONFIG_MACH_STM32F207)
         enable_clock_stm32f20x();
-    else if (CONFIG_MACH_STM32F401 || CONFIG_MACH_STM32F4x5)
+    else if (CONFIG_MACH_STM32F401 || CONFIG_MACH_STM32F411 || CONFIG_MACH_STM32F4x5)
         enable_clock_stm32f40x();
     else
         enable_clock_stm32f446();


### PR DESCRIPTION
## Summary
- treat the STM32F411 configuration the same as the STM32F401 for peripheral clock dividers
- ensure the STM32F411 uses the STM32F40x PLL setup path with pllp = 4 to maintain the 96 MHz SYSCLK and 48 MHz USB clock

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69057cb165688333b9a50db7bbc1d87f