### PR TITLE
Add STM32F411 Blackpill sample configuration - #2

### DIFF
--- a/config/sample-blackpill.cfg
+++ b/config/sample-blackpill.cfg
@@ -1,0 +1,120 @@
+# Sample configuration for a STM32F411 "Blackpill" control board
+#
+# The firmware should be compiled for the "STM32F411" micro-controller
+# with a 32KiB bootloader.
+#
+# See docs/Config_Reference.md for a description of parameters.
+
+[mcu]
+serial: /dev/serial/by-id/usb-Klipper_stm32f411xx-if00
+restart_method: command
+
+[printer]
+kinematics: cartesian
+max_velocity: 300
+max_accel: 3000
+max_z_velocity: 5
+max_z_accel: 100
+square_corner_velocity: 5.0
+
+[stepper_x]
+step_pin: PB9
+dir_pin: PB8
+enable_pin: !PB7
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PA0
+position_endstop: 0
+position_max: 220
+homing_speed: 50
+
+[stepper_y]
+step_pin: PB6
+dir_pin: !PB5
+enable_pin: !PB4
+microsteps: 16
+rotation_distance: 40
+endstop_pin: ^PA1
+position_endstop: 0
+position_max: 220
+homing_speed: 50
+
+[stepper_z]
+step_pin: PB3
+dir_pin: PB2
+enable_pin: !PB1
+microsteps: 16
+rotation_distance: 8
+endstop_pin: ^PA2
+position_endstop: 0
+position_max: 250
+
+[extruder]
+step_pin: PA7
+dir_pin: !PA6
+enable_pin: !PA5
+microsteps: 16
+rotation_distance: 7.710
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: PA8
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA4
+control: pid
+pid_kp: 21.527
+pid_ki: 1.063
+pid_kd: 108.982
+min_temp: 0
+max_temp: 250
+pressure_advance: 0.05
+
+[heater_bed]
+heater_pin: PA9
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PA3
+control: pid
+pid_kp: 60.0
+pid_ki: 0.9
+pid_kd: 900
+min_temp: 0
+max_temp: 120
+
+[fan]
+pin: PA10
+
+[heater_fan hotend_fan]
+pin: PA11
+heater: extruder
+heater_temp: 50.0
+
+[controller_fan electronics]
+pin: PA12
+stepper: stepper_x, stepper_y, stepper_z, extruder
+
+[output_pin status_led]
+pin: PC13
+value: 0
+shutdown_value: 0
+
+[safe_z_home]
+home_xy_position: 110, 110
+speed: 50
+z_hop: 10
+z_hop_speed: 15
+
+[idle_timeout]
+timeout: 600
+
+[gcode_macro START_PRINT]
+gcode:
+    G90
+    M83
+    G28
+    G1 Z5 F3000
+
+[gcode_macro END_PRINT]
+gcode:
+    M104 S0
+    M140 S0
+    G1 X0 Y200 F6000
+    M84

--- a/test/configs/stm32f411.config
+++ b/test/configs/stm32f411.config
@@ -1,0 +1,3 @@
+# Base config file for STM32F411 ARM processor
+CONFIG_MACH_STM32=y
+CONFIG_MACH_STM32F411=y

--- a/test/klippy/printers.test
+++ b/test/klippy/printers.test
@@ -69,6 +69,10 @@ CONFIG ../../config/printer-artillery-sidewinder-x3-plus-2024.cfg
 CONFIG ../../config/printer-creality-ender5-s1-2023.cfg
 CONFIG ../../config/printer-elegoo-neptune3-pro-2023.cfg
 
+# Printers using the stm32f411
+DICTIONARY stm32f411.dict
+CONFIG ../../config/sample-blackpill.cfg
+
 # Printers using the stm32f405
 DICTIONARY stm32f405.dict
 


### PR DESCRIPTION
## Summary
- add a build config entry for the STM32F411 MCU so CI compiles the Blackpill target
- provide a sample Blackpill printer configuration and register it with the regression printer matrix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900224c970883338794aea101fd92cc