### PR TITLE
Ensure STM32F411 builds include stm32f411xe header - #1

### DIFF
--- a/lib/stm32f4/include/stm32f4xx.h
+++ b/lib/stm32f4/include/stm32f4xx.h
@@ -8,8 +8,8 @@
   *          is using in the C source code, usually in main.c. This file contains:
   *           - Configuration section that allows to select:
   *              - The STM32F4xx device used in the target application
-  *              - To use or not the peripheral’s drivers in application code(i.e. 
-  *                code will be based on direct access to peripheral’s registers 
+  *              - To use or not the peripheralâ€™s drivers in application code(i.e. 
+  *                code will be based on direct access to peripheralâ€™s registers 
   *                rather than drivers API), this option is controlled by 
   *                "#define USE_HAL_DRIVER"
   *  
@@ -68,6 +68,11 @@
 #if !defined  (STM32F4)
 #define STM32F4
 #endif /* STM32F4 */
+
+/* Map legacy STM32F411 define to the expected STM32F411xE variant */
+#if defined(STM32F411) && !defined(STM32F411xE)
+#define STM32F411xE
+#endif
 
 /* Uncomment the line below according to the target STM32 device used in your
    application 


### PR DESCRIPTION
## Summary
- map the STM32F411 define to the expected STM32F411xE variant before selecting the device header

## Testing
- `gcc -E -DSTM32F411 -Ilib/stm32f4/include -Ilib/cmsis-core lib/stm32f4/include/stm32f4xx.h -o /tmp/stm32f4xx.i`


------
https://chatgpt.com/codex/tasks/task_e_69057cb5b2908333b6f14ce36cfa5064